### PR TITLE
Fix prepare_objdiff.py on Windows when the repo path has non-ASCII chars

### DIFF
--- a/prepare_objdiff.py
+++ b/prepare_objdiff.py
@@ -88,7 +88,10 @@ def get_dtk(tag: str) -> str:
             st = os.stat(bin_path)
             os.chmod(bin_path, st.st_mode | stat.S_IEXEC)
 
-    return bin_path
+    # Windows' CreateProcess fails to resolve a relative executable path when
+    # an ancestor directory name contains certain non-ASCII characters (e.g.
+    # an em dash); an absolute path avoids that resolution step entirely.
+    return os.path.abspath(bin_path)
 
 # Whether a section contains code or data
 SECTION_TYPES = {


### PR DESCRIPTION
CreateProcess couldn't resolve the relative dtk path when an ancestor folder name had a non-ASCII character in it (my repo folder has an em dash). Using an absolute path sidesteps it.