### PR TITLE
Decompile `DVDDiskCheck`

### DIFF
--- a/slices/wiimj2d.json
+++ b/slices/wiimj2d.json
@@ -68,6 +68,12 @@
     ],
     "slices": [
         {
+            "source": "lib/revolution/DVD/dvd.cpp",
+            "memoryRanges": {
+                ".text": "0x0-0x10"
+            }
+        },
+        {
             "source": "dol/bases/d_2d.cpp",
             "memoryRanges": {
                 ".text": "0x10-0xd90",

--- a/source/lib/revolution/DVD/dvd.cpp
+++ b/source/lib/revolution/DVD/dvd.cpp
@@ -1,0 +1,6 @@
+// TENTATIVE NAME (dtk auto-generated): unresolved low-level DVD disk-check routine.
+extern "C" void DVDCheckDiskBca(); ///< @unofficial
+
+extern "C" void DVDDiskCheck() {
+    DVDCheckDiskBca();
+}

--- a/syms.txt
+++ b/syms.txt
@@ -1,6 +1,6 @@
 memcpy=0x80004364
 memset=0x800046B4
-DVDDiskCheck=0x80006780
+DVDCheckDiskBca=0x801D0E30
 __ct__7mVec3_cFv=0x80015E30
 isFunsui__5dEn_cCFv=0x80020690
 endFunsui__5dEn_cFv=0x800206A0


### PR DESCRIPTION
Decompiles `DVDDiskCheck` (wiimj2d.dol), a trivial tail-call wrapper around `DVDCheckDiskBca`.