### PR TITLE
Decompile `sCrc::calcCRC32`

### DIFF
--- a/include/game/sLib/s_crc.hpp
+++ b/include/game/sLib/s_crc.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <types.h>
+
+/// @brief Wrapper around the runtime's CRC32 calculation function.
+/// @ingroup slib
+class sCrc {
+public:
+    /**
+     * @brief Calculates the CRC32 checksum of a buffer.
+     *
+     * @param data The buffer to checksum.
+     * @param size The size of the buffer, in bytes.
+     * @return The CRC32 checksum.
+     */
+    static u32 calcCRC32(const void *data, unsigned long size);
+};

--- a/include/game/sLib/s_crc.hpp
+++ b/include/game/sLib/s_crc.hpp
@@ -12,5 +12,5 @@ public:
      * @param size The size of the buffer, in bytes.
      * @return The CRC32 checksum.
      */
-    static u32 calcCRC32(const void *data, unsigned long size);
+    static ulong calcCRC32(const void *data, ulong size);
 };

--- a/include/lib/revolution/OS.h
+++ b/include/lib/revolution/OS.h
@@ -16,6 +16,7 @@ extern "C" {
 #include <revolution/OS/OSAudioSystem.h>
 #include <revolution/OS/OSCache.h>
 #include <revolution/OS/OSContext.h>
+#include <revolution/OS/OSCrc.h>
 #include <revolution/OS/OSError.h>
 #include <revolution/OS/OSExec.h>
 #include <revolution/OS/OSFastCast.h>

--- a/include/lib/revolution/OS/OSCrc.h
+++ b/include/lib/revolution/OS/OSCrc.h
@@ -1,0 +1,13 @@
+#ifndef RVL_SDK_OS_CRC_H
+#define RVL_SDK_OS_CRC_H
+#include <types.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ulong OSCalcCRC32(const void *, ulong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/slices/wiimj2d.json
+++ b/slices/wiimj2d.json
@@ -676,6 +676,12 @@
             }
         },
         {
+            "source": "dol/sLib/s_crc.cpp",
+            "memoryRanges": {
+                ".text": "0x158af0-0x158b00"
+            }
+        },
+        {
             "source": "dol/sLib/s_lib.cpp",
             "memoryRanges": {
                 ".text": "0x158b00-0x158fc0",

--- a/source/dol/sLib/s_crc.cpp
+++ b/source/dol/sLib/s_crc.cpp
@@ -1,8 +1,6 @@
 #include <game/sLib/s_crc.hpp>
+#include <revolution/OS.h>
 
-// TENTATIVE NAME (dtk auto-generated): unresolved CRC32 calculation routine.
-extern "C" u32 OSCalcCRC32(const void *data, unsigned long size); ///< @unofficial
-
-u32 sCrc::calcCRC32(const void *data, unsigned long size) {
+ulong sCrc::calcCRC32(const void *data, ulong size) {
     return OSCalcCRC32(data, size);
 }

--- a/source/dol/sLib/s_crc.cpp
+++ b/source/dol/sLib/s_crc.cpp
@@ -1,0 +1,8 @@
+#include <game/sLib/s_crc.hpp>
+
+// TENTATIVE NAME (dtk auto-generated): unresolved CRC32 calculation routine.
+extern "C" u32 OSCalcCRC32(const void *data, unsigned long size); ///< @unofficial
+
+u32 sCrc::calcCRC32(const void *data, unsigned long size) {
+    return OSCalcCRC32(data, size);
+}

--- a/syms.txt
+++ b/syms.txt
@@ -1,6 +1,7 @@
 memcpy=0x80004364
 memset=0x800046B4
 DVDDiskCheck=0x80006780
+OSCalcCRC32=0x801B8760
 __ct__7mVec3_cFv=0x80015E30
 isFunsui__5dEn_cCFv=0x80020690
 endFunsui__5dEn_cFv=0x800206A0

--- a/syms.txt
+++ b/syms.txt
@@ -1,7 +1,6 @@
 memcpy=0x80004364
 memset=0x800046B4
 DVDDiskCheck=0x80006780
-OSCalcCRC32=0x801B8760
 __ct__7mVec3_cFv=0x80015E30
 isFunsui__5dEn_cCFv=0x80020690
 endFunsui__5dEn_cFv=0x800206A0
@@ -492,6 +491,7 @@ OSSuspendThread=0x801B5C40
 OSSetThreadPriority=0x801B5FC0
 OSGetThreadPriority=0x801B60B0
 OSGetTime=0x801B60C0
+OSCalcCRC32=0x801B8760
 VIWaitForRetrace=0x801BCE30
 VIEnableDimming=0x801BE430
 PSMTXIdentity=0x801C0610


### PR DESCRIPTION
Decompiles `sCrc::calcCRC32` (wiimj2d.dol), a trivial tail-call wrapper around `OSCalcCRC32`.