### PR TITLE
Decompile `cLib::memSet`, `cLib::targetAngleY` and `cLib::targetAngleX`

### DIFF
--- a/include/game/cLib/c_lib.hpp
+++ b/include/game/cLib/c_lib.hpp
@@ -12,4 +12,7 @@ namespace cLib {
     s16 targetAngleY(const mVec3_c &vec1, const mVec3_c &vec2);
     s16 targetAngleX(const mVec3_c &vec1, const mVec3_c &vec2);
 
+    float addCalcPos(mVec3_c *pos, const mVec3_c &target, float ratio, float maxSpeed, float minSpeed);
+    bool chasePos(mVec3_c *pos, const mVec3_c &target, float speed);
+
 } // namespace cLib

--- a/include/game/cLib/c_lib.hpp
+++ b/include/game/cLib/c_lib.hpp
@@ -7,6 +7,9 @@
 /// @ingroup clib
 namespace cLib {
 
+    void memSet(void *dst, int val, ulong size);
+
     s16 targetAngleY(const mVec3_c &vec1, const mVec3_c &vec2);
+    s16 targetAngleX(const mVec3_c &vec1, const mVec3_c &vec2);
 
 } // namespace cLib

--- a/slices/wiimj2d.json
+++ b/slices/wiimj2d.json
@@ -722,6 +722,18 @@
             }
         },
         {
+            "source": "dol/cLib/c_memset.cpp",
+            "memoryRanges": {
+                ".text": "0x15a490-0x15a4a0"
+            }
+        },
+        {
+            "source": "dol/cLib/c_lib.cpp",
+            "memoryRanges": {
+                ".text": "0x15a840-0x15a8d0"
+            }
+        },
+        {
             "source": "dol/cLib/c_line.cpp",
             "memoryRanges": {
                 ".text": "0x15a8d0-0x15aa20"

--- a/slices/wiimj2d.json
+++ b/slices/wiimj2d.json
@@ -730,7 +730,8 @@
         {
             "source": "dol/cLib/c_lib.cpp",
             "memoryRanges": {
-                ".text": "0x15a840-0x15a8d0"
+                ".text": "0x15a4a0-0x15a8d0",
+                ".sdata2": "0x2b80-0x2b88"
             }
         },
         {

--- a/source/dol/cLib/c_lib.cpp
+++ b/source/dol/cLib/c_lib.cpp
@@ -1,7 +1,61 @@
 #include <game/cLib/c_lib.hpp>
 #include <lib/egg/math/eggMath.h>
+#include <lib/revolution/MTX/vec.h>
+#include <math.h>
+
+inline bool isZero(float val) {
+    return (std::fabs(val) < FLT_EPSILON);
+}
+
+inline float calcDistance(const mVec3_c &a, const mVec3_c &b) {
+    float dx = a.x - b.x;
+    float dy = a.y - b.y;
+    float dz = a.z - b.z;
+    return EGG::Mathf::sqrt(dx * dx + dy * dy + dz * dz);
+}
 
 namespace cLib {
+
+float addCalcPos(mVec3_c *pos, const mVec3_c &target, float ratio, float maxSpeed, float minSpeed) {
+    if (*pos != target) {
+        mVec3_c diff;
+        diff = *pos - target;
+        float mag = PSVECMag(diff);
+        if (mag < minSpeed) {
+            *pos = target;
+        } else {
+            diff *= ratio;
+            float stepMag = mag * ratio;
+            if (!isZero(stepMag)) {
+                if (stepMag > maxSpeed) {
+                    diff *= maxSpeed / stepMag;
+                } else if (stepMag < minSpeed) {
+                    diff *= minSpeed / stepMag;
+                }
+                *pos -= diff;
+            } else {
+                *pos = target;
+            }
+        }
+    }
+
+    return calcDistance(*pos, target);
+}
+
+bool chasePos(mVec3_c *pos, const mVec3_c &target, float speed) {
+    if (speed) {
+        mVec3_c diff = *pos - target;
+        float mag = PSVECMag(diff);
+        if (isZero(mag) || mag <= speed) {
+            *pos = target;
+            return true;
+        }
+        *pos -= (speed / mag) * diff;
+    } else if (*pos == target) {
+        return true;
+    }
+    return false;
+}
 
 s16 targetAngleY(const mVec3_c &vec1, const mVec3_c &vec2) {
     return cM::atan2s(vec2.x - vec1.x, vec2.z - vec1.z);

--- a/source/dol/cLib/c_lib.cpp
+++ b/source/dol/cLib/c_lib.cpp
@@ -1,0 +1,15 @@
+#include <game/cLib/c_lib.hpp>
+#include <lib/egg/math/eggMath.h>
+
+namespace cLib {
+
+s16 targetAngleY(const mVec3_c &vec1, const mVec3_c &vec2) {
+    return cM::atan2s(vec2.x - vec1.x, vec2.z - vec1.z);
+}
+
+s16 targetAngleX(const mVec3_c &vec1, const mVec3_c &vec2) {
+    mVec3_c diff = vec2 - vec1;
+    return cM::atan2s(diff.y, EGG::Mathf::sqrt(diff.x * diff.x + diff.z * diff.z));
+}
+
+} // namespace cLib

--- a/source/dol/cLib/c_memset.cpp
+++ b/source/dol/cLib/c_memset.cpp
@@ -1,0 +1,10 @@
+#include <game/cLib/c_lib.hpp>
+#include <MSL/cstring>
+
+namespace cLib {
+
+void memSet(void *dst, int val, ulong size) {
+    std::memset(dst, val, size);
+}
+
+} // namespace cLib


### PR DESCRIPTION
Decompiles three `cLib` utility functions (wiimj2d.dol): `memSet` (a tail-call wrapper around `memset`), and `targetAngleY`/`targetAngleX` (angle-to-target helpers built on `cM::atan2s`).