### PR TITLE
Retry doxygen download on transient network errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Generate documentation
         run: |
           sudo apt-get install -y graphviz fonts-freefont-ttf
-          curl https://www.doxygen.nl/files/doxygen-1.15.0.linux.bin.tar.gz --output doxygen-1.15.0.linux.bin.tar.gz
+          curl --retry 5 --retry-all-errors --retry-delay 5 --fail https://www.doxygen.nl/files/doxygen-1.15.0.linux.bin.tar.gz --output doxygen-1.15.0.linux.bin.tar.gz
           tar xzf doxygen-1.15.0.linux.bin.tar.gz
           cd doxygen-1.15.0
           sudo make install


### PR DESCRIPTION
The `generate_docs` job's `curl` call to doxygen.nl has no retry logic, so a single dropped connection fails the whole job (seen on PR #130 — `curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR` partway through the 74MB download). `--retry-all-errors` makes curl retry on connection failures too, not just HTTP 5xx responses.

Small, self-contained CI robustness fix — does not touch any decompiled code.